### PR TITLE
Update jsreport version to 3.13

### DIFF
--- a/jsreport.Binary/download.ps1
+++ b/jsreport.Binary/download.ps1
@@ -1,2 +1,2 @@
 ﻿[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-(new-object System.Net.WebClient).DownloadFile('https://github.com/jsreport/jsreport/releases/download/3.11.0/jsreport-win.zip','jsreport.zip')
+(new-object System.Net.WebClient).DownloadFile('https://github.com/jsreport/jsreport/releases/download/3.13.0/jsreport-win.zip','jsreport.zip')


### PR DESCRIPTION
Update jsreport version to the actual version 3.13 due a trojana report of the old version 3.11 on virustotal.com

The result of the check is here: [Result](https://www.virustotal.com/gui/file/dc6c2038cc07a569e532e9e2494ab5ed5885e5005c4a44404320255e6495b4c5)

Can you please update the jsreport version from 3.11 to the newest version?
The newest version doesn't have this issue.